### PR TITLE
removed : from cifs share path value

### DIFF
--- a/docs/cifs.md
+++ b/docs/cifs.md
@@ -57,7 +57,7 @@ volumes:
   data:
     driver: cifs
     driver_opts:
-      share: cifshost:/share
+      share: cifshost/share
 
 services:
   hello:


### PR DESCRIPTION
the `:` doesn't work for CIFS.